### PR TITLE
Small Python cleanups. Everything passes flake8 now.

### DIFF
--- a/run.bash
+++ b/run.bash
@@ -2,7 +2,7 @@
 #SBATCH --cpus-per-task=16
 
 # https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
-set -euo pipefail
+set -Eeuo pipefail
 
 printf "Running snakemake...\n"
 snakemake -j 16 --keep-going --restart-times 3 --latency-wait 60 --rerun-incomplete --use-conda

--- a/scripts/alignment_counts.py
+++ b/scripts/alignment_counts.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
+
 """Aggregate alignment counts across accessions."""
 
-
+import snakemake
 import subprocess
 
 import pandas as pd
@@ -16,7 +18,8 @@ records = []
 
 for accession, bam, high_ident_bam in zip(accessions, bams, high_ident_bams):
     for name, bamfile in [('any', bam), ('high_identity', high_ident_bam)]:
-        res = subprocess.run(['samtools', 'view', '-c', bamfile], capture_output=True)
+        res = subprocess.run(['samtools', 'view', '-c', bamfile],
+                             capture_output=True)
         assert res.returncode == 0
         count = int(res.stdout)
         assert count >= 0

--- a/scripts/analyze_variants.py
+++ b/scripts/analyze_variants.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
+
 """Analyze variants called by ``ivar`` relative to outgroups."""
 
-
+import snakemake
 import pandas as pd
 
 
@@ -9,7 +11,7 @@ site_map = pd.read_csv(snakemake.input.site_map)
 assert len(snakemake.params.descriptors) == len(snakemake.input.variants)
 variants = (pd.concat([pd.read_csv(f, sep='\t').assign(**descriptor)
                        for (f, descriptor) in zip(snakemake.input.variants,
-                                                 snakemake.params.descriptors)
+                                                  snakemake.params.descriptors)
                        ],
                       ignore_index=True)
             .rename(columns={'POS': 'site'})

--- a/scripts/fastq_instrument_info.py
+++ b/scripts/fastq_instrument_info.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python
+
 """Information about the machine used to generate FASTQ from header."""
 
 
+import snakemake
 import collections
-import itertools
 import re
 
 import pandas as pd
@@ -19,13 +21,14 @@ fastq_name = snakemake.wildcards.fastq
 # groups:
 #  - the machine / run / flowcell / lane ID
 #  - the cluster location (should be unique for all reads)
-illumina_regex = re.compile('(?P<info>[\w\-]+:\d+:[\w\-]+:\d+):(?P<cluster>\d+:\d+:\d+)')
+illumina_regex = re.compile(
+    r'(?P<info>[\w\-]+:\d+:[\w\-]+:\d+):(?P<cluster>\d+:\d+:\d+)')
 info = collections.defaultdict(int)
 clusters = collections.defaultdict(int)
 
 # For BGI-SEQ, get flow-cell serial number as from here:
 # https://github.com/powellgenomicslab/BGI_vs_Illumina_Benchmark
-bgi_regex = re.compile('(?P<info>[A-Z0-9]{10}L\d+)(?P<cluster>C\d+R\d+/[12])')
+bgi_regex = re.compile(r'(?P<info>[A-Z0-9]{10}L\d+)(?P<cluster>C\d+R\d+/[12])')
 
 print(f"Parsing {fastq_file}")
 
@@ -52,5 +55,5 @@ if max(clusters.values()) > 1:
 
 with open(output_csv, 'w') as f:
     f.write('fastq,info\n')
-    for info in info.keys():
+    for info in info:
         f.write(f"{fastq_name},{info}\n")

--- a/scripts/high_ident_bam.py
+++ b/scripts/high_ident_bam.py
@@ -1,8 +1,9 @@
+#!/usr/bin/env python
+
 """Implements ``snakemake`` rule `high_ident_bam`."""
 
-
+import snakemake
 import pysam
-
 
 min_length = snakemake.params.min_length
 min_identity = snakemake.params.min_identity
@@ -21,7 +22,8 @@ with pysam.AlignmentFile(snakemake.input.bam, 'rb') as bamfile:
                 try:
                     nm = read.get_tag('NM')
                 except KeyError:
-                    raise KeyError(f"read in {bam=} lacks NM tag")
+                    raise KeyError(
+                        f"read in {snakemake.input.bam=} lacks NM tag")
                 assert 0 <= nm, f"{nm=}, {length=}"
                 identity = 1 - nm / length
                 if identity >= min_identity:

--- a/scripts/outgroup_map.py
+++ b/scripts/outgroup_map.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python
+
 """Build map of identities in reference to outgroups from alignment."""
 
 
+import snakemake
 import Bio.SeqIO
 
 import pandas as pd

--- a/scripts/trim3_polyA.py
+++ b/scripts/trim3_polyA.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env python
+
 """Script for rule ``scripts/trim3_polyA.py``."""
 
-
+import snakemake
 import Bio.SeqIO
 
 seq = Bio.SeqIO.read(snakemake.input.fasta, 'fasta')
-while seq.seq[-1] in ['A', 'a']:
-    seq.seq = seq.seq[: -1]
+seq.seq = seq.seq.rstrip('Aa')
 Bio.SeqIO.write([seq], snakemake.output.fasta, 'fasta')


### PR DESCRIPTION
Hi Jesse. Here are some very small suggested Python clean-ups for you, if you'd like them. They're all trivial. I don't use `snakemake` but I think the `import snakemake` is correct. I added it because it stops tools like `flake8` from complaining about the unknown name and also editors from flagging it as unknown.